### PR TITLE
refactor: Import Mapsの活用とVSCode設定の最適化

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "denoland.vscode-deno"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,15 @@
   "[typescript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
-  "cSpell.words": ["atproto", "bluesky", "bsky", "Graphemer", "Twitterbot"],
-  "deno.codeLens.implementations": true,
-  "deno.codeLens.references": true,
-  "deno.codeLens.referencesAllFunctions": true,
-  "deno.enable": true,
-  "deno.lint": true,
-  "deno.suggest.imports.hosts": {
-    "https://deno.land": true
+  "[javascript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
   },
-  "deno.unstable": true
+  "cSpell.words": ["atproto", "bluesky", "bsky", "Graphemer", "Twitterbot"],
+  "deno.enable": true,
+  "deno.enablePaths": [
+    "./github-star-notifier",
+    "./link-insight-notifier",
+    "./rss-feed-notifier"
+  ],
+  "deno.lint": true
 }

--- a/github-star-notifier/.vscode/settings.json
+++ b/github-star-notifier/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.config": "./deno.jsonc"
+}

--- a/github-star-notifier/deno.jsonc
+++ b/github-star-notifier/deno.jsonc
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "lib": ["deno.window"]
   },
   "nodeModulesDir": "auto",
   "imports": {
     "@std/dotenv": "jsr:@std/dotenv@^0.225.0/load",
-    "@std/async": "jsr:@std/async@^1.0.0",
+    "@std/async": "jsr:@std/async@^1.0.0/abortable",
     "@std/log": "jsr:@std/log@^0.224.0",
     "@atproto/api": "npm:@atproto/api@^0.13.0",
     "@mikaelporttila/rss": "jsr:@mikaelporttila/rss@^1.1.0",

--- a/github-star-notifier/deno.lock
+++ b/github-star-notifier/deno.lock
@@ -2,34 +2,26 @@
   "version": "5",
   "specifiers": {
     "jsr:@maxim-mazurok/sax-ts@1.2.13": "1.2.13",
-    "jsr:@mikaelporttila/rss@*": "1.1.2",
+    "jsr:@mikaelporttila/rss@*": "1.1.3",
+    "jsr:@mikaelporttila/rss@^1.1.0": "1.1.3",
     "jsr:@std/assert@*": "1.0.15",
-    "jsr:@std/async@*": "1.0.13",
-    "jsr:@std/dotenv@*": "0.225.5",
-    "jsr:@std/fmt@^1.0.5": "1.0.8",
-    "jsr:@std/fs@^1.0.11": "1.0.19",
+    "jsr:@std/async@1": "1.0.15",
+    "jsr:@std/dotenv@0.225": "0.225.5",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/io@~0.225.2": "0.225.2",
-    "jsr:@std/log@0.224": "0.224.14",
-    "npm:@atproto/api@*": "0.15.16",
+    "npm:@atproto/api@*": "0.13.35",
     "npm:@atproto/api@0.13": "0.13.35",
-    "npm:@google/genai@*": "1.25.0",
     "npm:@google/genai@^1.25.0": "1.25.0",
-    "npm:@google/generative-ai@*": "0.24.1",
     "npm:@imagemagick/magick-wasm@0.0.31": "0.0.31",
-    "npm:@mozilla/readability@*": "0.6.0",
     "npm:@mozilla/readability@0.5": "0.5.0",
-    "npm:jsdom@*": "26.1.0",
     "npm:jsdom@24": "24.1.3",
-    "npm:open-graph-scraper@*": "6.10.0",
     "npm:open-graph-scraper@6": "6.10.0"
   },
   "jsr": {
     "@maxim-mazurok/sax-ts@1.2.13": {
       "integrity": "9f2f9a3ac1b142400940a4c9e916656fe63d4710a78102aeb8e08e863de2c76d"
     },
-    "@mikaelporttila/rss@1.1.2": {
-      "integrity": "064a7b1be7b25ddefca1491712c6921fa003bd279683325630e6acedf31bb98a",
+    "@mikaelporttila/rss@1.1.3": {
+      "integrity": "2d6f09935489233fba13228c9e1670ef02aaeebffc9b1e63432eee3b34d12533",
       "dependencies": [
         "jsr:@maxim-mazurok/sax-ts"
       ]
@@ -40,31 +32,14 @@
         "jsr:@std/internal"
       ]
     },
-    "@std/async@1.0.13": {
-      "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
+    "@std/async@1.0.15": {
+      "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
     },
     "@std/dotenv@0.225.5": {
       "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
     },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
-    },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06"
-    },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
-    },
-    "@std/io@0.225.2": {
-      "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7"
-    },
-    "@std/log@0.224.14": {
-      "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
-      "dependencies": [
-        "jsr:@std/fmt",
-        "jsr:@std/fs",
-        "jsr:@std/io"
-      ]
     }
   },
   "npm": {
@@ -84,28 +59,15 @@
         "@atproto/common-web",
         "@atproto/lexicon",
         "@atproto/syntax@0.3.4",
-        "@atproto/xrpc@0.6.12",
+        "@atproto/xrpc",
         "await-lock",
         "multiformats",
         "tlds",
         "zod"
       ]
     },
-    "@atproto/api@0.15.16": {
-      "integrity": "sha512-ZNBrzBg2l0lHreKik1lJn8lrhAktwlY8NUPBU/hO9dwjAnDHQTiSzNFZt65dp9djmqZ75sX/VJ+heNuaJBvnhQ==",
-      "dependencies": [
-        "@atproto/common-web",
-        "@atproto/lexicon",
-        "@atproto/syntax@0.4.0",
-        "@atproto/xrpc@0.7.0",
-        "await-lock",
-        "multiformats",
-        "tlds",
-        "zod"
-      ]
-    },
-    "@atproto/common-web@0.4.2": {
-      "integrity": "sha512-vrXwGNoFGogodjQvJDxAeP3QbGtawgZute2ed1XdRO0wMixLk3qewtikZm06H259QDJVu6voKC5mubml+WgQUw==",
+    "@atproto/common-web@0.4.3": {
+      "integrity": "sha512-nRDINmSe4VycJzPo6fP/hEltBcULFxt9Kw7fQk6405FyAWZiTluYHlXOnU7GkQfeUK44OENG1qFTBcmCJ7e8pg==",
       "dependencies": [
         "graphemer",
         "multiformats",
@@ -113,11 +75,11 @@
         "zod"
       ]
     },
-    "@atproto/lexicon@0.4.11": {
-      "integrity": "sha512-btefdnvNz2Ao2I+qbmj0F06HC8IlrM/IBz6qOBS50r0S6uDf5tOO+Mv2tSVdimFkdzyDdLtBI1sV36ONxz2cOw==",
+    "@atproto/lexicon@0.4.14": {
+      "integrity": "sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==",
       "dependencies": [
         "@atproto/common-web",
-        "@atproto/syntax@0.4.0",
+        "@atproto/syntax@0.4.1",
         "iso-datestring-validator",
         "multiformats",
         "zod"
@@ -126,8 +88,8 @@
     "@atproto/syntax@0.3.4": {
       "integrity": "sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg=="
     },
-    "@atproto/syntax@0.4.0": {
-      "integrity": "sha512-b9y5ceHS8YKOfP3mdKmwAx5yVj9294UN7FG2XzP6V5aKUdFazEYRnR9m5n5ZQFKa3GNvz7de9guZCJ/sUTcOAA=="
+    "@atproto/syntax@0.4.1": {
+      "integrity": "sha512-CJdImtLAiFO+0z3BWTtxwk6aY5w4t8orHTMVJgkf++QRJWTxPbIFko/0hrkADB7n2EruDxDSeAgfUGehpH6ngw=="
     },
     "@atproto/xrpc@0.6.12": {
       "integrity": "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w==",
@@ -136,15 +98,8 @@
         "zod"
       ]
     },
-    "@atproto/xrpc@0.7.0": {
-      "integrity": "sha512-SfhP9dGx2qclaScFDb58Jnrmim5nk4geZXCqg6sB0I/KZhZEkr9iIx1hLCp+sxkIfEsmEJjeWO4B0rjUIJW5cw==",
-      "dependencies": [
-        "@atproto/lexicon",
-        "zod"
-      ]
-    },
-    "@csstools/color-helpers@5.0.2": {
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA=="
+    "@csstools/color-helpers@5.1.0": {
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
     },
     "@csstools/css-calc@2.1.4_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
@@ -153,8 +108,8 @@
         "@csstools/css-tokenizer"
       ]
     },
-    "@csstools/css-color-parser@3.0.10_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
-      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+    "@csstools/css-color-parser@3.1.0_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dependencies": [
         "@csstools/color-helpers",
         "@csstools/css-calc",
@@ -178,20 +133,14 @@
         "ws"
       ]
     },
-    "@google/generative-ai@0.24.1": {
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="
-    },
     "@imagemagick/magick-wasm@0.0.31": {
       "integrity": "sha512-QNivAUxSaItuiY8ziI/vRy6TtoecD7TOsD1LGZCG3wv8lfbdGbIj2QiJk0FlGkGwAVR966NlD3mkxPNvQrvq0w=="
     },
     "@mozilla/readability@0.5.0": {
       "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ=="
     },
-    "@mozilla/readability@0.6.0": {
-      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="
-    },
-    "agent-base@7.1.3": {
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
     "asynckit@0.4.0": {
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
@@ -232,8 +181,8 @@
         "domutils"
       ]
     },
-    "cheerio@1.1.0": {
-      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+    "cheerio@1.1.2": {
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
       "dependencies": [
         "cheerio-select",
         "dom-serializer",
@@ -244,7 +193,7 @@
         "parse5",
         "parse5-htmlparser2-tree-adapter",
         "parse5-parser-stream",
-        "undici@7.10.0",
+        "undici@7.16.0",
         "whatwg-mimetype"
       ]
     },
@@ -254,8 +203,8 @@
         "delayed-stream"
       ]
     },
-    "css-select@5.1.0": {
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+    "css-select@5.2.2": {
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dependencies": [
         "boolbase",
         "css-what",
@@ -264,11 +213,11 @@
         "nth-check"
       ]
     },
-    "css-what@6.1.0": {
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    "css-what@6.2.2": {
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
     },
-    "cssstyle@4.4.0": {
-      "integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+    "cssstyle@4.6.0": {
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dependencies": [
         "@asamuzakjp/css-color",
         "rrweb-cssom@0.8.0"
@@ -281,14 +230,14 @@
         "whatwg-url@14.2.0"
       ]
     },
-    "debug@4.4.1": {
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
     },
-    "decimal.js@10.5.0": {
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+    "decimal.js@10.6.0": {
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
     },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
@@ -524,32 +473,7 @@
         "rrweb-cssom@0.7.1",
         "saxes",
         "symbol-tree",
-        "tough-cookie@4.1.4",
-        "w3c-xmlserializer",
-        "webidl-conversions@7.0.0",
-        "whatwg-encoding",
-        "whatwg-mimetype",
-        "whatwg-url@14.2.0",
-        "ws",
-        "xml-name-validator"
-      ]
-    },
-    "jsdom@26.1.0": {
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dependencies": [
-        "cssstyle",
-        "data-urls",
-        "decimal.js",
-        "html-encoding-sniffer",
-        "http-proxy-agent",
-        "https-proxy-agent",
-        "is-potential-custom-element-name",
-        "nwsapi",
-        "parse5",
-        "rrweb-cssom@0.8.0",
-        "saxes",
-        "symbol-tree",
-        "tough-cookie@5.1.2",
+        "tough-cookie",
         "w3c-xmlserializer",
         "webidl-conversions@7.0.0",
         "whatwg-encoding",
@@ -613,8 +537,8 @@
         "boolbase"
       ]
     },
-    "nwsapi@2.2.20": {
-      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="
+    "nwsapi@2.2.22": {
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="
     },
     "open-graph-scraper@6.10.0": {
       "integrity": "sha512-JTuaO/mWUPduYCIQvunmsQnfGpSRFUTEh4k5cW2KOafJxTm3Z99z25/c1oO9QnIh2DK7ol5plJAq3EUVy+5xyw==",
@@ -622,7 +546,7 @@
         "chardet",
         "cheerio",
         "iconv-lite",
-        "undici@6.21.3"
+        "undici@6.22.0"
       ]
     },
     "parse5-htmlparser2-tree-adapter@7.1.0": {
@@ -680,18 +604,8 @@
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "tlds@1.259.0": {
-      "integrity": "sha512-AldGGlDP0PNgwppe2quAvuBl18UcjuNtOnDuUkqhd6ipPqrYYBt3aTxK1QTsBVknk97lS2JcafWMghjGWFtunw==",
-      "bin": true
-    },
-    "tldts-core@6.1.86": {
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
-    },
-    "tldts@6.1.86": {
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dependencies": [
-        "tldts-core"
-      ],
+    "tlds@1.260.0": {
+      "integrity": "sha512-78+28EWBhCEE7qlyaHA9OR3IPvbCLiDh3Ckla593TksfFc9vfTsgvH7eS+dr3o9qr31gwGbogcI16yN91PoRjQ==",
       "bin": true
     },
     "tough-cookie@4.1.4": {
@@ -701,12 +615,6 @@
         "punycode",
         "universalify",
         "url-parse"
-      ]
-    },
-    "tough-cookie@5.1.2": {
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dependencies": [
-        "tldts"
       ]
     },
     "tr46@0.0.3": {
@@ -724,11 +632,11 @@
         "multiformats"
       ]
     },
-    "undici@6.21.3": {
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="
+    "undici@6.22.0": {
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw=="
     },
-    "undici@7.10.0": {
-      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw=="
+    "undici@7.16.0": {
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="
     },
     "universalify@0.2.0": {
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
@@ -779,8 +687,8 @@
         "webidl-conversions@3.0.1"
       ]
     },
-    "ws@8.18.2": {
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="
+    "ws@8.18.3": {
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
     },
     "xml-name-validator@5.0.0": {
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
@@ -788,8 +696,8 @@
     "xmlchars@2.2.0": {
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "zod@3.25.67": {
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "remote": {

--- a/github-star-notifier/main.ts
+++ b/github-star-notifier/main.ts
@@ -1,6 +1,6 @@
-import 'jsr:@std/dotenv/load';
-import AtprotoAPI from 'npm:@atproto/api';
-import type { AtpAgent } from 'npm:@atproto/api';
+import '@std/dotenv';
+import * as AtprotoAPI from '@atproto/api';
+import type { AtpAgent } from '@atproto/api';
 import { validateAndGetEnv } from './src/config/env.ts';
 import { BLUESKY_SERVICE_URL, MAX_POST_COUNT } from './src/config/constants.ts';
 import { logger } from './src/utils/logger.ts';

--- a/github-star-notifier/src/application/formatters/BlueskyPostFormatter.ts
+++ b/github-star-notifier/src/application/formatters/BlueskyPostFormatter.ts
@@ -1,4 +1,4 @@
-import AtprotoAPI from 'npm:@atproto/api';
+import * as AtprotoAPI from '@atproto/api';
 import type { BlueskyFormatterParams, BlueskyPostContent } from '../../types/index.ts';
 import { logger } from '../../utils/logger.ts';
 const { RichText } = AtprotoAPI;

--- a/github-star-notifier/src/application/usecases/FetchAndNotifyUseCase.ts
+++ b/github-star-notifier/src/application/usecases/FetchAndNotifyUseCase.ts
@@ -4,8 +4,8 @@
  * フィードを取得し、SNSに投稿するユースケース。
  */
 
-import type { AtpAgent } from 'npm:@atproto/api';
-import type { FeedEntry } from 'jsr:@mikaelporttila/rss';
+import type { AtpAgent } from '@atproto/api';
+import type { FeedEntry } from '@mikaelporttila/rss';
 import type {
   IContentRepository,
   IFeedRepository,

--- a/github-star-notifier/src/domain/repositories/IFeedRepository.ts
+++ b/github-star-notifier/src/domain/repositories/IFeedRepository.ts
@@ -4,7 +4,7 @@
  * RSSフィードの取得とタイムスタンプ管理を抽象化します。
  */
 
-import type { FeedEntry } from 'jsr:@mikaelporttila/rss';
+import type { FeedEntry } from '@mikaelporttila/rss';
 
 /**
  * フィードリポジトリのインターフェース

--- a/github-star-notifier/src/domain/repositories/INotificationRepository.ts
+++ b/github-star-notifier/src/domain/repositories/INotificationRepository.ts
@@ -4,7 +4,7 @@
  * SNS投稿とWebhook通知を抽象化します。
  */
 
-import type { AtpAgent, RichText } from 'npm:@atproto/api';
+import type { AtpAgent, RichText } from '@atproto/api';
 
 /**
  * 通知リポジトリのインターフェース

--- a/github-star-notifier/src/infrastructure/external/ArticleExtractor.ts
+++ b/github-star-notifier/src/infrastructure/external/ArticleExtractor.ts
@@ -2,8 +2,8 @@
  * Webページから読みやすいテキストコンテンツを抽出するモジュール
  */
 
-import { JSDOM } from 'npm:jsdom';
-import { Readability } from 'npm:@mozilla/readability';
+import { JSDOM } from 'jsdom';
+import { Readability } from '@mozilla/readability';
 import { logger } from '../../utils/logger.ts';
 
 /**

--- a/github-star-notifier/src/infrastructure/external/BlueskyClient.ts
+++ b/github-star-notifier/src/infrastructure/external/BlueskyClient.ts
@@ -1,5 +1,5 @@
-import { abortable } from 'jsr:@std/async';
-import AtprotoAPI from 'npm:@atproto/api';
+import { abortable } from '@std/async';
+import * as AtprotoAPI from '@atproto/api';
 import type { PublishToBlueskyParams, UploadBlobResult } from '../../types/index.ts';
 import { RETRY_CONFIG } from '../../config/constants.ts';
 import { retry } from '../../utils/retry.ts';

--- a/github-star-notifier/src/infrastructure/external/ImageProcessor.ts
+++ b/github-star-notifier/src/infrastructure/external/ImageProcessor.ts
@@ -1,9 +1,4 @@
-import {
-  ImageMagick,
-  type IMagickImage,
-  initialize,
-  MagickFormat,
-} from 'https://deno.land/x/imagemagick_deno@0.0.31/mod.ts';
+import { ImageMagick, type IMagickImage, initialize, MagickFormat } from 'imagemagick';
 import type { ProcessedImageResult } from '../../types/index.ts';
 import { IMAGE_CONFIG, RETRY_CONFIG } from '../../config/constants.ts';
 import { retry } from '../../utils/retry.ts';
@@ -19,6 +14,8 @@ export default async (url: string, timestamp: number): Promise<ProcessedImageRes
 
         // 画像が取得できなかった場合はエラーをスロー
         if (!res.ok || !contentType?.includes('image')) {
+          // レスポンスボディを消費してリソースリークを防ぐ
+          await res.body?.cancel();
           throw new Error(`Failed to fetch image: ${res.status} ${res.statusText}`);
         }
         return res;

--- a/github-star-notifier/src/infrastructure/external/OgpFetcher.ts
+++ b/github-star-notifier/src/infrastructure/external/OgpFetcher.ts
@@ -2,7 +2,7 @@
  * Open Graph Protocol (OGP) データを取得するモジュール
  */
 
-import ogs from 'npm:open-graph-scraper';
+import ogs from 'open-graph-scraper';
 import { OpenGraphData, Url } from '../../domain/models/index.ts';
 import { USER_AGENT } from '../../config/constants.ts';
 import { logger } from '../../utils/logger.ts';

--- a/github-star-notifier/src/infrastructure/external/RssFeedClient.ts
+++ b/github-star-notifier/src/infrastructure/external/RssFeedClient.ts
@@ -2,7 +2,7 @@
  * RSS feedから記事リストを取得するモジュール
  */
 
-import { type FeedEntry, parseFeed } from 'jsr:@mikaelporttila/rss';
+import { type FeedEntry, parseFeed } from '@mikaelporttila/rss';
 import { MAX_FEED_ITEMS, PATTERNS } from '../../config/constants.ts';
 import { logger } from '../../utils/logger.ts';
 import { NetworkError } from '../../utils/errors.ts';

--- a/github-star-notifier/src/infrastructure/external/SummaryGenerator.ts
+++ b/github-star-notifier/src/infrastructure/external/SummaryGenerator.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from 'npm:@google/genai';
+import { GoogleGenAI } from '@google/genai';
 import { Summary } from '../../domain/models/index.ts';
 import { GEMINI_CONFIG, RETRY_CONFIG } from '../../config/constants.ts';
 import { retry } from '../../utils/retry.ts';

--- a/github-star-notifier/src/infrastructure/repositories/FeedRepository.ts
+++ b/github-star-notifier/src/infrastructure/repositories/FeedRepository.ts
@@ -4,7 +4,7 @@
  * RSSフィードの取得とタイムスタンプ管理の実装。
  */
 
-import type { FeedEntry } from 'jsr:@mikaelporttila/rss';
+import type { FeedEntry } from '@mikaelporttila/rss';
 import type { IFeedRepository } from '../../domain/repositories/index.ts';
 import fetchFeedItems from '../external/RssFeedClient.ts';
 

--- a/github-star-notifier/src/infrastructure/repositories/NotificationRepository.ts
+++ b/github-star-notifier/src/infrastructure/repositories/NotificationRepository.ts
@@ -4,7 +4,7 @@
  * SNS投稿とWebhook通知の実装。
  */
 
-import type { AtpAgent, RichText } from 'npm:@atproto/api';
+import type { AtpAgent, RichText } from '@atproto/api';
 import type { INotificationRepository } from '../../domain/repositories/index.ts';
 import publishToBluesky from '../external/BlueskyClient.ts';
 import sendWebhookNotification from '../external/WebhookClient.ts';

--- a/github-star-notifier/src/types/index.ts
+++ b/github-star-notifier/src/types/index.ts
@@ -2,8 +2,8 @@
  * アプリケーション全体で使用する型定義
  */
 
-import { type FeedEntry } from 'jsr:@mikaelporttila/rss';
-import { type AtpAgent, type RichText } from 'npm:@atproto/api';
+import { type FeedEntry } from '@mikaelporttila/rss';
+import { type AtpAgent, type RichText } from '@atproto/api';
 
 // Feed関連の型
 export interface FeedItem extends FeedEntry {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,8 @@ pre-commit:
     # フォーマットチェック
     format:
       glob: "github-star-notifier/**/*.{ts,tsx,js,jsx,json,jsonc}"
-      run: deno fmt --check {staged_files}
+      run: deno fmt {staged_files}
+      stage_fixed: true
 
     # リントチェック
     lint:

--- a/link-insight-notifier/.vscode/settings.json
+++ b/link-insight-notifier/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.config": "./deno.jsonc"
+}

--- a/rss-feed-notifier/.vscode/settings.json
+++ b/rss-feed-notifier/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.config": "./deno.jsonc"
+}


### PR DESCRIPTION
主な変更点:
- インポートパスをImport Maps経由に統一
  - npm:/jsr:プレフィックスを除去し、deno.jsoncの定義を活用
  - AtprotoAPIを名前空間インポート(import * as)に変更
- VSCode設定を最適化
  - マルチプロジェクト対応のためenablePathsを明示
  - 各プロジェクトに個別のdeno.config設定を追加
  - Deno拡張機能を推奨に追加
- deno.jsoncのコンパイラオプションを明示化
