### PR TITLE
fix: OGP画像の相対URLを絶対URLに変換する処理を追加

### DIFF
--- a/rss-feed-notifier/src/infrastructure/repositories/OpenGraphRepository.ts
+++ b/rss-feed-notifier/src/infrastructure/repositories/OpenGraphRepository.ts
@@ -43,6 +43,73 @@ export class OpenGraphRepository implements IOpenGraphRepository {
       return OpenGraphData.empty();
     }
 
-    return OpenGraphData.fromRaw(rawOgp);
+    // 画像URLが相対パスの場合、絶対URLに変換
+    const normalizedOgp = this.normalizeImageUrl(rawOgp, url.toString());
+
+    return OpenGraphData.fromRaw(normalizedOgp);
+  }
+
+  /**
+   * OGP画像URLが相対パスの場合、絶対URLに変換する
+   *
+   * @param rawOgp - 取得したOGPデータ
+   * @param baseUrl - ベースURL（元のページURL）
+   * @returns 画像URLが正規化されたOGPデータ
+   */
+  private normalizeImageUrl(
+    rawOgp: {
+      ogTitle?: string;
+      ogDescription?: string;
+      ogImage?: Array<{ url: string }> | { url: string };
+    },
+    baseUrl: string,
+  ): typeof rawOgp {
+    if (!rawOgp.ogImage) {
+      return rawOgp;
+    }
+
+    // 画像URLを取得
+    const imageUrl = Array.isArray(rawOgp.ogImage) ? rawOgp.ogImage[0]?.url : rawOgp.ogImage.url;
+
+    if (!imageUrl) {
+      return rawOgp;
+    }
+
+    // 既に有効な絶対URLの場合はそのまま返す
+    if (Url.isValid(imageUrl)) {
+      return rawOgp;
+    }
+
+    // 相対URLを絶対URLに変換
+    try {
+      const absoluteUrl = Url.fromRelative(imageUrl, baseUrl);
+      logger.info('相対URLを絶対URLに変換しました', {
+        relativeUrl: imageUrl,
+        absoluteUrl: absoluteUrl.toString(),
+      });
+
+      // 変換後のURLでOGPデータを更新
+      if (Array.isArray(rawOgp.ogImage)) {
+        return {
+          ...rawOgp,
+          ogImage: [{ url: absoluteUrl.toString() }],
+        };
+      }
+      return {
+        ...rawOgp,
+        ogImage: { url: absoluteUrl.toString() },
+      };
+    } catch (error) {
+      // 変換に失敗した場合は画像なしとして扱う
+      logger.warn('相対URLの変換に失敗しました', {
+        relativeUrl: imageUrl,
+        baseUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        ...rawOgp,
+        ogImage: undefined,
+      };
+    }
   }
 }


### PR DESCRIPTION
- OpenGraphRepositoryにnormalizeImageUrlメソッドを追加
- 相対パスの画像URLをベースURLを使って絶対URLに変換
- 変換に失敗した場合は画像なしとして扱う
- Url.fromRelativeメソッドを活用
