### PR TITLE
fix(rss-feed-notifier): 無効なBluesky facetを除外する

### DIFF
--- a/rss-feed-notifier/src/application/formatters/BlueskyPostFormatter.ts
+++ b/rss-feed-notifier/src/application/formatters/BlueskyPostFormatter.ts
@@ -10,6 +10,33 @@ import { OpenGraphData } from '../../domain/models/OpenGraphData.ts';
 import { TEXT_LIMITS } from '../../config/constants.ts';
 import { logger } from '../../utils/logger.ts';
 
+/** detectFacets が生成するファセットの最小型 */
+type AutoDetectedFacet = NonNullable<RichText['facets']>[number];
+
+/**
+ * detectFacets で自動検出されたファセットから有効なものだけを残す
+ *
+ * - DID 解決に失敗したメンション（did が空）は除外
+ * - リンクファセットは手動追加するため自動検出分は除外
+ */
+export function filterValidAutoDetectedFacets(
+  facets: AutoDetectedFacet[],
+): AutoDetectedFacet[] {
+  return facets.filter((facet) =>
+    facet.features.every((feature) => {
+      if (feature.$type === 'app.bsky.richtext.facet#mention') {
+        return 'did' in feature &&
+          typeof feature.did === 'string' &&
+          feature.did.length > 0;
+      }
+      if (feature.$type === 'app.bsky.richtext.facet#link') {
+        return false;
+      }
+      return true;
+    })
+  );
+}
+
 /**
  * 文字列の書記素クラスタ数をカウントする
  */
@@ -62,6 +89,8 @@ export class BlueskyPostFormatter {
     const richText = new RichText({ text: postBodyText });
     await richText.detectFacets(this.agent);
 
+    const autoDetectedFacets = filterValidAutoDetectedFacets(richText.facets ?? []);
+
     // リンクファセットを先頭に追加
     richText.facets = [
       {
@@ -76,7 +105,7 @@ export class BlueskyPostFormatter {
           },
         ],
       },
-      ...(richText.facets || []),
+      ...autoDetectedFacets,
     ];
 
     return richText;

--- a/rss-feed-notifier/src/infrastructure/external/BlueskyClient.ts
+++ b/rss-feed-notifier/src/infrastructure/external/BlueskyClient.ts
@@ -5,8 +5,8 @@
  */
 
 import { abortable } from '@std/async';
+import * as AtprotoAPI from '@atproto/api';
 import { AtpAgent, type BlobRef, RichText } from '@atproto/api';
-import type AtprotoAPI from '@atproto/api';
 import { logger } from '../../utils/logger.ts';
 import { retry } from '../../utils/retry.ts';
 import { BLUESKY_LANGUAGE, RETRY_CONFIG } from '../../config/constants.ts';

--- a/rss-feed-notifier/tests/application/formatters/BlueskyPostFormatter_test.ts
+++ b/rss-feed-notifier/tests/application/formatters/BlueskyPostFormatter_test.ts
@@ -1,18 +1,68 @@
 /**
  * BlueskyPostFormatter のテスト
- *
- * 注: BskyAgentのモックが必要なため、基本的な動作のみをテスト
  */
 import { assertEquals } from '@std/assert';
+import { filterValidAutoDetectedFacets } from '../../../src/application/formatters/BlueskyPostFormatter.ts';
 
-Deno.test('BlueskyPostFormatter の基本テスト（プレースホルダー）', () => {
-  // BlueskyPostFormatterはBskyAgentに依存しているため、
-  // モックを使った統合テストが望ましい
-  // ここでは基本的な動作確認のみ
-  assertEquals(true, true);
+const mentionFeature = (did: string) => ({
+  $type: 'app.bsky.richtext.facet#mention' as const,
+  did,
 });
 
-// TODO: BskyAgentのモックを使った実際のテストを追加
-// - createRichText() のテスト
-// - getDescription() のテスト
-// - formatLinkText / formatTitle の切り詰めは createRichText 経由で検証
+const linkFeature = (uri: string) => ({
+  $type: 'app.bsky.richtext.facet#link' as const,
+  uri,
+});
+
+const tagFeature = (tag: string) => ({
+  $type: 'app.bsky.richtext.facet#tag' as const,
+  tag,
+});
+
+const facet = (
+  byteStart: number,
+  byteEnd: number,
+  features: ReturnType<typeof mentionFeature | typeof linkFeature | typeof tagFeature>[],
+) => ({
+  index: { byteStart, byteEnd },
+  features,
+});
+
+Deno.test('filterValidAutoDetectedFacets - 空 DID のメンション facet を除外する', () => {
+  const facets = [
+    facet(105, 117, [mentionFeature('')]),
+    facet(0, 10, [tagFeature('test')]),
+  ];
+
+  const result = filterValidAutoDetectedFacets(facets);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].features[0].$type, 'app.bsky.richtext.facet#tag');
+});
+
+Deno.test('filterValidAutoDetectedFacets - 自動検出リンク facet を除外する', () => {
+  const facets = [
+    facet(0, 28, [linkFeature('https://example.com/ent..')]),
+    facet(0, 10, [tagFeature('test')]),
+  ];
+
+  const result = filterValidAutoDetectedFacets(facets);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].features[0].$type, 'app.bsky.richtext.facet#tag');
+});
+
+Deno.test('filterValidAutoDetectedFacets - 有効なメンション facet は保持する', () => {
+  const facets = [
+    facet(10, 20, [mentionFeature('did:plc:validhandle')]),
+  ];
+
+  const result = filterValidAutoDetectedFacets(facets);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].features[0], mentionFeature('did:plc:validhandle'));
+});
+
+Deno.test('filterValidAutoDetectedFacets - 空配列を渡すと空配列を返す', () => {
+  assertEquals(filterValidAutoDetectedFacets([]), []);
+});


### PR DESCRIPTION
- detectFacets後に空DIDのメンションfacetを除外
- 自動検出リンクfacetを除外し手動追加のみ残す
- filterValidAutoDetectedFacetsの単体テストを追加