### PR TITLE
refactor(notifier): vite-node を Module Runner に移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ pnpm run typecheck  # tsc --noEmit
 
 ## 各 Notifier の実行
 
+各 notifier は Vite の [Module Runner](https://vite.dev/guide/api-environment-runtimes)（`runnerImport`）経由で TypeScript を実行します。共通ランナーは [`scripts/run-module-runner.mjs`](scripts/run-module-runner.mjs) です。
+
 ```bash
 cd github-star-notifier
 dotenvx run -- pnpm start

--- a/github-star-notifier/README.md
+++ b/github-star-notifier/README.md
@@ -164,7 +164,7 @@ echo "0" > data/.timestamp
 詳細は [`.github/workflows/github-star-notifier.yml`](../.github/workflows/github-star-notifier.yml) を参照してください。
 
 - Node.js 24 + pnpm 11
-- `dotenvx run -- pnpm start` で実行
+- `dotenvx run -- pnpm start` で実行（Vite Module Runner 経由）
 - `data/.timestamp` を Actions cache で永続化
 
 ## ライセンス

--- a/github-star-notifier/package.json
+++ b/github-star-notifier/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "vite-node main.ts",
+    "start": "node ../scripts/run-module-runner.mjs main.ts",
     "check": "pnpm --dir .. run check",
     "check:fix": "pnpm --dir .. run check:fix",
     "test": "pnpm --dir .. exec vp test run --project github-star-notifier",

--- a/link-insight-notifier/package.json
+++ b/link-insight-notifier/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "vite-node main.ts",
+    "start": "node ../scripts/run-module-runner.mjs main.ts",
     "check": "pnpm --dir .. run check",
     "check:fix": "pnpm --dir .. run check:fix",
     "typecheck": "pnpm --dir .. exec tsc --noEmit -p link-insight-notifier/tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "@types/jsdom": "^28.0.3",
     "@types/node": "^26.0.1",
+    "@voidzero-dev/vite-plus-core": "0.2.1",
     "typescript": "7.0.1-rc",
-    "vite-node": "^6.0.0",
     "vite-plus": "^0.2.1",
     "vitest": "^4.1.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@0.2.1
+  vitest: 4.1.9
+
 importers:
 
   .:
@@ -14,17 +18,17 @@ importers:
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
+      '@voidzero-dev/vite-plus-core':
+        specifier: 0.2.1
+        version: 0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@7.0.1-rc)
       typescript:
         specifier: 7.0.1-rc
         version: 7.0.1-rc
-      vite-node:
-        specifier: ^6.0.0
-        version: 6.0.0(@types/node@26.0.1)(esbuild@0.28.1)
       vite-plus:
         specifier: ^0.2.1
         version: 0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jsdom@29.1.1)(typescript@7.0.1-rc)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1))
       vitest:
-        specifier: ^4.1.9
+        specifier: 4.1.9
         version: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1))
 
   github-star-notifier:
@@ -1355,10 +1359,6 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
-  cac@7.0.0:
-    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
-    engines: {node: '>=20.19.0'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1949,11 +1949,6 @@ packages:
     peerDependenciesMeta:
       '@napi-rs/canvas':
         optional: true
-
-  vite-node@6.0.0:
-    resolution: {integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
 
   vite-plus@0.2.1:
     resolution: {integrity: sha512-q5q/Y38UkWFsNg1JO+RyRdPUqoewaSqIlMyK2p83GKNUvf4D38Ntb3PToRTDZbTRh7mWt+B+d0DQBv4nCDpMcQ==}
@@ -2932,8 +2927,6 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
-  cac@7.0.0: {}
-
   chai@6.2.2: {}
 
   chardet@2.2.0: {}
@@ -3616,27 +3609,6 @@ snapshots:
   unicode-segmenter@0.14.5: {}
 
   unpdf@1.6.2: {}
-
-  vite-node@6.0.0(@types/node@26.0.1)(esbuild@0.28.1):
-    dependencies:
-      cac: 7.0.0
-      es-module-lexer: 2.1.0
-      obug: 2.1.3
-      pathe: 2.0.3
-      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vite-plus@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(jsdom@29.1.1)(typescript@7.0.1-rc)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,10 @@ packages:
   - 'rss-feed-notifier'
   - 'link-insight-notifier'
 
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@0.2.1
+  vitest: 4.1.9
+
 allowBuilds:
   '@google/genai': true
   esbuild: true

--- a/rss-feed-notifier/package.json
+++ b/rss-feed-notifier/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "vite-node main.ts",
+    "start": "node ../scripts/run-module-runner.mjs main.ts",
     "check": "pnpm --dir .. run check",
     "check:fix": "pnpm --dir .. run check:fix",
     "test": "pnpm --dir .. exec vp test run --project rss-feed-notifier",

--- a/scripts/run-module-runner.mjs
+++ b/scripts/run-module-runner.mjs
@@ -1,0 +1,18 @@
+import { runnerImport } from '@voidzero-dev/vite-plus-core';
+import { resolve } from 'node:path';
+
+const entryArg = process.argv[2];
+if (!entryArg) {
+  console.error('Usage: node scripts/run-module-runner.mjs <entry.ts>');
+  process.exit(1);
+}
+
+const root = process.cwd();
+const entry = resolve(root, entryArg);
+
+try {
+  await runnerImport(entry, { root });
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## PR概要

- メンテナンスモードの `vite-node` を廃止し、Vite 内蔵 Module Runner（`runnerImport`）で各 notifier を実行する
- 共通ランナー `scripts/run-module-runner.mjs` を追加し、3 notifier の `start` を統一
- `@voidzero-dev/vite-plus-core` を明示依存化し、pnpm overrides で vite / vitest を固定

## 主な実装内容

1. **Module Runner ランナーの追加**
   - `scripts/run-module-runner.mjs` を新規作成
   - `runnerImport` で各 notifier の `main.ts` を実行（import 失敗時は exit code 1）

2. **各 notifier の start スクリプト更新**
   - `github-star-notifier` / `rss-feed-notifier` / `link-insight-notifier` の `start` を `node ../scripts/run-module-runner.mjs main.ts` に変更

3. **依存関係の整理**
   - ルート `package.json` から `vite-node` を削除
   - `@voidzero-dev/vite-plus-core@0.2.1` を devDependencies に追加
   - `pnpm-workspace.yaml` に vite / vitest の overrides を追加

4. **ドキュメント更新**
   - ルート `README.md` と `github-star-notifier/README.md` に Module Runner 実行の説明を追加
