### PR TITLE
fix(ci): setup-vp を pnpm 標準セットアップに戻す

### DIFF
--- a/.cursor/rules/monorepo-rule.mdc
+++ b/.cursor/rules/monorepo-rule.mdc
@@ -30,7 +30,7 @@ pnpm workspace で 3 つの notifier パッケージを管理する。
 
 # Git hooks（lefthook）
 
-- **pre-commit**: ステージされたファイルの glob に一致するものに対し fmt / lint / tsc（パッケージ別 + ドキュメント + ルート設定）
-- **pre-push**: CI と同一の `pnpm run check` → `pnpm run test` → `pnpm run typecheck` を順に実行
+- **pre-commit**: ステージ済みファイルに `pnpm exec vp lint --fix` / `pnpm exec vp fmt` を実行
+- **pre-push**: `pnpm exec vp check --no-fmt --no-lint` → `pnpm exec vp test` を順に実行
 
 詳細なコマンド一覧はルート `AGENTS.md` を参照すること。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
-          version: '0.2.1'
-          cache: true
-          run-install: false
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: vp install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Check
-        run: vp check
+        run: pnpm run check
 
       - name: Test
-        run: vp test
+        run: pnpm run test

--- a/.github/workflows/github-star-notifier.yml
+++ b/.github/workflows/github-star-notifier.yml
@@ -14,15 +14,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
-          version: '0.2.1'
-          cache: true
-          run-install: false
+          cache: 'pnpm'
       - name: Install dependencies
-        run: vp install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
         working-directory: ${{ github.workspace }}
       - name: Create directories
         run: mkdir -p data temp

--- a/.github/workflows/link-insight-notifier.yml
+++ b/.github/workflows/link-insight-notifier.yml
@@ -22,15 +22,15 @@ jobs:
           chrome-version: latest
       - name: Verify Chrome
         run: '${{ steps.setup_chrome.outputs.chrome-path }} --version'
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
-          version: '0.2.1'
-          cache: true
-          run-install: false
+          cache: 'pnpm'
       - name: Install dependencies
-        run: vp install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
         working-directory: ${{ github.workspace }}
       - name: Install dotenvx
         run: curl -sfS https://dotenvx.sh/install.sh | sh

--- a/.github/workflows/rss-feed-notifier.yml
+++ b/.github/workflows/rss-feed-notifier.yml
@@ -17,16 +17,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
-          version: '0.2.1'
-          cache: true
-          run-install: false
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: vp install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
         working-directory: ${{ github.workspace }}
 
       - name: Create directories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,9 @@
 ## Dev environment tips
 
 - 初回セットアップ（mise）: `mise trust && mise install && pnpm install`
-- 初回セットアップ（mise なし）: `vp install`
-- `.node-version`: Node 26 の正本（mise / Vite+ / CI が参照）
-- `packageManager`: pnpm 11.9.0 の厳密ピン（`vp install` が参照）
-- mise の pnpm / vp を優先する: `vp env off`（初回のみ。vp 0.2.x では `env` サブコマンド未対応のため mise 利用を推奨）
+- 初回セットアップ（mise なし）: `pnpm install`
+- `.node-version`: Node 26 の正本（mise / CI が参照）
+- `packageManager`: pnpm 11.9.0 の厳密ピン
 - サブプロジェクトへ移動して作業する。ルートから `pnpm --filter <package-name>` でも実行可能
 - 各パッケージ名は各ディレクトリの `package.json` の `name` フィールドを参照
 
@@ -35,9 +34,9 @@
 
 ## Testing instructions
 
-- CI 定義: `.github/workflows/`（`voidzero-dev/setup-vp` + `vp install --frozen-lockfile` / `vp check` / `vp test`）
-- コミット前: lefthook pre-commit がステージファイルに対し fmt / lint / tsc を実行（glob に一致するファイルのみ）
-- プッシュ前: lefthook pre-push が `pnpm run check` → `pnpm run test` → `pnpm run typecheck` を順に実行（CI より typecheck が追加）
+- CI 定義: `.github/workflows/`（`pnpm/action-setup` + `actions/setup-node` + `pnpm install --frozen-lockfile` / `pnpm run check` / `pnpm run test`）
+- コミット前: lefthook pre-commit がステージ済みファイルに `pnpm exec vp lint --fix` / `pnpm exec vp fmt` を実行
+- プッシュ前: lefthook pre-push が `pnpm exec vp check --no-fmt --no-lint` → `pnpm exec vp test` を順に実行
 - マージ前に `pnpm run check && pnpm run test` を通すこと
 - 単体テストの絞り込み: `vp test --project <project-name> -t "<test name>"`
 

--- a/README.md
+++ b/README.md
@@ -20,20 +20,35 @@
 ```bash
 mise trust
 mise install
-vp env off   # mise の Node/pnpm を優先（初回のみ）
 pnpm install
 ```
 
 ## 開発コマンド（ルート）
 
 ```bash
-pnpm run check      # Oxfmt + Oxlint + tsc 型チェック
+pnpm run check      # Oxfmt + Oxlint + 型チェック（CI と同じフルチェック）
 pnpm run check:fix  # フォーマット自動修正 + Lint + 型チェック
 pnpm run test       # Vitest（全プロジェクト）
 pnpm run test:github-star-notifier
 pnpm run test:rss-feed-notifier
-pnpm run typecheck  # tsc --noEmit
+pnpm run typecheck  # tsc --noEmit（手動実行用）
 ```
+
+## Git hooks（lefthook）
+
+| フック     | コマンド                                                      | 役割                                               |
+| ---------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| pre-commit | `pnpm exec vp lint --fix` / `pnpm exec vp fmt`                | ステージ済みファイルの lint 自動修正とフォーマット |
+| pre-push   | `pnpm exec vp check --no-fmt --no-lint` → `pnpm exec vp test` | 型チェックとテスト                                 |
+
+## CI / GitHub Actions
+
+CI と notifier デプロイ workflow は `pnpm/action-setup` + `actions/setup-node` で Node / pnpm をセットアップする（`setup-vp` は使用しない）。
+
+| workflow      | 実行内容                                                              |
+| ------------- | --------------------------------------------------------------------- |
+| CI            | `pnpm install --frozen-lockfile` → `pnpm run check` → `pnpm run test` |
+| Notifier 各種 | `pnpm install --frozen-lockfile` → `dotenvx run -- pnpm start`        |
 
 ## 依存関係の自動更新（Dependabot）
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,67 +1,24 @@
 # Lefthook Configuration
-# Git hooks の自動実行設定
-# pre-push は check / test / typecheck を実行（CI は check / test のみ）
+# pre-commit: ステージ済みファイルの lint 自動修正 + フォーマット
+# pre-push: 型チェック + テスト（CI はフル check + test）
 
 pre-commit:
   parallel: true
   commands:
-    format-docs:
-      glob: '{AGENTS.md,**/*.md,.cursor/**/*.mdc}'
-      run: vp fmt {staged_files}
+    lint:
+      glob: '**/*.{ts,tsx}'
+      run: pnpm exec vp lint --fix {staged_files}
+
+    fmt:
+      glob: '**/*.{ts,tsx,js,jsx,json,jsonc,md,mdc,yml,yaml}'
+      run: pnpm exec vp fmt {staged_files}
       stage_fixed: true
-
-    format-root:
-      glob: '{.node-version,package.json,pnpm-workspace.yaml,lefthook.yml,vite.config.ts,tsconfig*.json,.github/workflows/*.{yml,yaml}}'
-      run: vp fmt {staged_files}
-      stage_fixed: true
-
-    format-github-star:
-      glob: 'github-star-notifier/**/*.{ts,tsx,js,jsx,json,jsonc}'
-      run: vp fmt {staged_files}
-      stage_fixed: true
-
-    lint-github-star:
-      glob: 'github-star-notifier/**/*.{ts,tsx}'
-      run: vp lint {staged_files}
-
-    type-check-github-star:
-      glob: 'github-star-notifier/**/*.{ts,tsx}'
-      run: pnpm exec tsc --noEmit -p github-star-notifier/tsconfig.json
-
-    format-rss-feed:
-      glob: 'rss-feed-notifier/**/*.{ts,tsx,js,jsx,json,jsonc}'
-      run: vp fmt {staged_files}
-      stage_fixed: true
-
-    lint-rss-feed:
-      glob: 'rss-feed-notifier/**/*.{ts,tsx}'
-      run: vp lint {staged_files}
-
-    type-check-rss-feed:
-      glob: 'rss-feed-notifier/**/*.{ts,tsx}'
-      run: pnpm exec tsc --noEmit -p rss-feed-notifier/tsconfig.json
-
-    format-link-insight:
-      glob: 'link-insight-notifier/**/*.{ts,tsx,js,jsx,json,jsonc}'
-      run: vp fmt {staged_files}
-      stage_fixed: true
-
-    lint-link-insight:
-      glob: 'link-insight-notifier/**/*.{ts,tsx}'
-      run: vp lint {staged_files}
-
-    type-check-link-insight:
-      glob: 'link-insight-notifier/**/*.{ts,tsx}'
-      run: pnpm exec tsc --noEmit -p link-insight-notifier/tsconfig.json
 
 pre-push:
   parallel: false
   commands:
-    check:
-      run: pnpm run check
+    typecheck:
+      run: pnpm exec vp check --no-fmt --no-lint
 
     test:
-      run: pnpm run test
-
-    typecheck:
-      run: pnpm run typecheck
+      run: pnpm exec vp test


### PR DESCRIPTION
## PR概要

- PR #38 で導入した `setup-vp` が PATH 上の `pnpm` を vp ラッパーに置き換え、notifier workflow の `dotenvx run -- pnpm start` が `☠ Unknown command: pnpm start` で失敗していた
- CI 基盤から `setup-vp` 依存を外し、`pnpm/action-setup` + `actions/setup-node` に復元する
- lefthook を 12 コマンドから 4 コマンドに簡素化し、hooks / CI / ドキュメントの役割分担を整理する

### 主な実装内容

1. **GitHub Actions 4 workflow を pnpm 標準セットアップに復元**
   - `voidzero-dev/setup-vp` → `pnpm/action-setup` + `actions/setup-node`（`node-version-file: '.node-version'`）
   - `vp install --frozen-lockfile` → `pnpm install --frozen-lockfile`
   - CI: `pnpm run check` → `pnpm run test`（typecheck ステップは追加しない）

2. **lefthook を 4 コマンド構成に簡素化**
   - pre-commit: `pnpm exec vp lint --fix` / `pnpm exec vp fmt`（ステージ済みファイル）
   - pre-push: `pnpm exec vp check --no-fmt --no-lint` → `pnpm exec vp test`

3. **ドキュメント整合**
   - `AGENTS.md` / `README.md` / `.cursor/rules/monorepo-rule.mdc` の CI・hooks 記述を更新
